### PR TITLE
Fix hangup when unbuffered process output exceeds 64 KB.

### DIFF
--- a/os/src/main/kotlin/com/gojuno/commander/os/Processes.kt
+++ b/os/src/main/kotlin/com/gojuno/commander/os/Processes.kt
@@ -61,10 +61,11 @@ fun process(
             }
 
             val process: Process = ProcessBuilder(command)
+                    .redirectErrorStream(true)
                     .let {
                         when (unbufferedOutput) {
-                            true -> it
-                            else -> it.redirectErrorStream(true).redirectOutput(ProcessBuilder.Redirect.to(outputFile))
+                            true -> it.redirectOutput(File("/dev/null"))
+                            else -> it.redirectOutput(ProcessBuilder.Redirect.to(outputFile))
                         }
                     }
                     .start()

--- a/os/src/main/kotlin/com/gojuno/commander/os/Processes.kt
+++ b/os/src/main/kotlin/com/gojuno/commander/os/Processes.kt
@@ -66,7 +66,7 @@ fun process(
                     .redirectErrorStream(true)
                     .let {
                         when (unbufferedOutput) {
-                            true -> it.redirectOutput(File(os().nullDeviceFilePath))
+                            true -> it.redirectOutput(os().nullDeviceFile())
                             else -> it.redirectOutput(ProcessBuilder.Redirect.to(outputFile))
                         }
                     }
@@ -140,11 +140,13 @@ internal fun os(): Os {
     }
 }
 
-internal val Os.nullDeviceFilePath: String
-    get() = when(this) {
+internal fun Os.nullDeviceFile(): File {
+    val path = when (this) {
         Linux, Mac -> "/dev/null"
         Windows -> "NUL"
     }
+    return File(path)
+}
 
 fun Long.nanosToHumanReadableTime(): String {
     var seconds: Long = TimeUnit.NANOSECONDS.toSeconds(this)

--- a/os/src/test/kotlin/com/gojuno/commander/os/ProcessesSpec.kt
+++ b/os/src/test/kotlin/com/gojuno/commander/os/ProcessesSpec.kt
@@ -13,7 +13,7 @@ class ProcessesSpec : Spek({
 
     describe("null device file") {
 
-        val result = File(os().nullDeviceFilePath)
+        val result = os().nullDeviceFile()
 
         it("is writable") {
             assertThat(result).canWrite()

--- a/os/src/test/kotlin/com/gojuno/commander/os/ProcessesSpec.kt
+++ b/os/src/test/kotlin/com/gojuno/commander/os/ProcessesSpec.kt
@@ -5,10 +5,20 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.on
+import java.io.File
 import java.util.concurrent.TimeUnit.MINUTES
 import java.util.concurrent.TimeUnit.SECONDS
 
 class ProcessesSpec : Spek({
+
+    describe("null device file") {
+
+        val result = File(os().nullDeviceFilePath)
+
+        it("is writable") {
+            assertThat(result).canWrite()
+        }
+    }
 
     describe("nanosToHumanReadableTime") {
 


### PR DESCRIPTION
Fixes issue mentioned in https://github.com/gojuno/composer/pull/109#issuecomment-343688962.

For example when installing APK on a remote device output looks like that:
`[  x%] /data/local/tmp/app-dev-debug.apk[K`
`ESC[K` at the end is an Erase Line ANSI sequence.
Such lines are printed periodically, so they all appear as a single line in terminal (unless `dumb` or similar terminal is used). If installation time is large enough there might be multiple lines with the same content.

Additionally if `Process` output is not redirected anywhere and it reaches 64 KB, execution hangs. When output is unbuffered it is written to file using `script` command so output of the `Process` can be discarded by redirecting to `/dev/null`.

Tested on Linux with Oracle JDK:
```
$ java -version
java version "1.8.0_152"
Java(TM) SE Runtime Environment (build 1.8.0_152-b16)
Java HotSpot(TM) 64-Bit Server VM (build 25.152-b16, mixed mode)
```