### PR TITLE
fail with meaningful message if env ANDROID_HOME missing

### DIFF
--- a/android/src/main/kotlin/com/gojuno/commander/android/Adb.kt
+++ b/android/src/main/kotlin/com/gojuno/commander/android/Adb.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MINUTES
 import java.util.concurrent.TimeUnit.SECONDS
 
-val androidHome: String by lazy { System.getenv("ANDROID_HOME") }
+val androidHome: String by lazy { requireNotNull(System.getenv("ANDROID_HOME")) { "Please specify ANDROID_HOME env variable" } }
 val adb: String by lazy { "$androidHome/platform-tools/adb" }
 private val buildTools: String? by lazy {
     File(androidHome, "build-tools")


### PR DESCRIPTION
Previously composer tests would fail with
```
Parameter specified as non-null is null: method kotlin.collections.ArraysKt___ArraysKt.sortedArray, parameter $receiver
java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.collections.ArraysKt___ArraysKt.sortedArray, parameter $receiver
	at kotlin.collections.ArraysKt___ArraysKt.sortedArray(_Arrays.kt)
	at com.gojuno.commander.android.AdbKt$buildTools$2.invoke(Adb.kt:19)
...
```