### PR TITLE
Allow Downgrade when installing app

### DIFF
--- a/android/src/main/kotlin/com/gojuno/commander/android/Adb.kt
+++ b/android/src/main/kotlin/com/gojuno/commander/android/Adb.kt
@@ -78,7 +78,7 @@ fun AdbDevice.log(message: String) = com.gojuno.commander.os.log("[$id] $message
 fun AdbDevice.installApk(pathToApk: String, timeout: Pair<Int, TimeUnit> = 2 to MINUTES): Observable<Unit> {
     val adbDevice = this
     val installApk = process(
-            commandAndArgs = listOf(adb, "-s", adbDevice.id, "install", "-r", pathToApk),
+            commandAndArgs = listOf(adb, "-s", adbDevice.id, "install", "-r", "-d", pathToApk),
             unbufferedOutput = true,
             timeout = timeout
     )


### PR DESCRIPTION
If downgrades are not allowed, errors like this show up: 
`Downgrade detected: Update version code 20 is older than current 21`

The additional `-d` flag tells PackageManager to just allow the downgrade.