### PR TITLE
Allow installApk to install a testOnly APK

### DIFF
--- a/android/src/main/kotlin/com/gojuno/commander/android/Adb.kt
+++ b/android/src/main/kotlin/com/gojuno/commander/android/Adb.kt
@@ -83,7 +83,7 @@ fun AdbDevice.log(message: String) = com.gojuno.commander.os.log("[$id] $message
 fun AdbDevice.installApk(pathToApk: String, timeout: Pair<Int, TimeUnit> = 2 to MINUTES): Observable<Unit> {
     val adbDevice = this
     val installApk = process(
-            commandAndArgs = listOf(adb, "-s", adbDevice.id, "install", "-r", pathToApk),
+            commandAndArgs = listOf(adb, "-s", adbDevice.id, "install", "-t", "-r", pathToApk),
             unbufferedOutput = true,
             timeout = timeout
     )


### PR DESCRIPTION
Just makes it a little more resilient, in the sense that if you built the APK from the IDE and haven't set testOnly="false" in the manifest, this will still successfully install it, which one would probably expect for an adb-commanding tool. Just ran into this with composer and found the install command here.